### PR TITLE
Fix incorrect git ref version choices; See #12

### DIFF
--- a/handle.go
+++ b/handle.go
@@ -293,7 +293,7 @@ func (h *Handler) chooseRef(refs []*gitRef, v Version) (chosenHash string, ok bo
 
 		// Add it to the version list for sorting.
 		verList = append(verList, refVersion{
-			Version: v,
+			Version: refV,
 			gitRef:  ref,
 		})
 	}


### PR DESCRIPTION
Sorting with always the same Version does not really make sense.
We parsed the version for the ref but never used it for sorting or anything else but for choosing if it is the right major version